### PR TITLE
docs(README.md): fix sd installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ My ROS2 package template
 - [sd](https://github.com/chmln/sd)
 
   ```sh
-  bin install https://github.com/chmln/sd
+  bin install https://github.com/chmln/sd ~/.local/bin/sd
   # When it asks "Multiple matches found, please select one:",
   # select [1] sd-{version}-x86_64-unknown-linux-gnu
   ```


### PR DESCRIPTION
Current instructions install `sd` into ` ~/.local/bin/sd-unknown-gnu`.

Updated instructions install it into ` ~/.local/bin/sd`.